### PR TITLE
Use BioPython version < 1.78

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ seaborn>=0.8.1
 six>=1.11.0
 Click>=6.0
 click-help-colors>=0.3
-Biopython>=1.70
+Biopython>=1.70,<1.78


### PR DESCRIPTION
[BioPython version 1.78 no longer uses `Bio.Alphabet`](https://github.com/biopython/biopython/blob/master/NEWS.rst#4-september-2020-biopython-178). 
`pyseglogo` uses `Bio.Alphabet` in [expected_frequencies.py](https://github.com/saketkc/pyseqlogo/blob/master/pyseqlogo/expected_frequencies.py).
Therefore, restrict BioPython to versions lower then 1.78.